### PR TITLE
WebRTC hotfix

### DIFF
--- a/custom_components/reolink_rest/binary_sensor.py
+++ b/custom_components/reolink_rest/binary_sensor.py
@@ -269,7 +269,7 @@ async def async_setup_entry(
                         )
                         hass.create_task(_coordinator.async_request_refresh())
                 subscription = None
-                if not bool(coordinator.data.ports["onvifEnable"]):
+                if not bool(coordinator.data.ports.get("onvifEnable", True)):
                     coordinator.logger.warning(
                         "ONVIF not enabled for device %s, forcing polling mode",
                         coordinator.data.device.name,

--- a/custom_components/reolink_rest/manifest.json
+++ b/custom_components/reolink_rest/manifest.json
@@ -3,7 +3,7 @@
   "name": "Reolink IP Device",
   "documentation": "https://github.com/xannor/ha_reolink_rest",
   "issue_tracker": "https://github.com/xannor/ha_reolink_rest/issues",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "iot_class": "local_polling",
   "requirements": ["async-reolink.rest==0.5.8"],
   "dependencies": ["camera"],

--- a/custom_components/reolink_rest/push.py
+++ b/custom_components/reolink_rest/push.py
@@ -268,7 +268,7 @@ class PushManager:
                 return (response.status, et.fromstring(text))
 
     def _get_onvif_base(self, config_entry: ConfigEntry, device_data: EntityData):
-        if not bool(device_data.ports["onvifEnable"]):
+        if not bool(device_data.ports.get("onvifEnable", True)):
             return None
         discovery: dict = config_entry.options.get(OPT_DISCOVERY, {})
         host = config_entry.data.get(CONF_HOST, discovery.get("ip", None))


### PR DESCRIPTION
Hotfix for WebRTC usurping the RTMP protocol, but not working with ReoLink's RTMP streams 
(only RTSP outputs will allow WebRTC for now until I can verify it works)

Fixed older firmware not supporting disabling of ports (thus not reporting if they are enabled)
